### PR TITLE
Refactor message classes

### DIFF
--- a/src/main/java/com/froyo/messages/AbstractResponse.java
+++ b/src/main/java/com/froyo/messages/AbstractResponse.java
@@ -1,7 +1,6 @@
 package com.froyo.messages;
 
 import com.froyo.messages.exceptions.ValidationConstraintRemote;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 
@@ -14,12 +13,11 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 @NoArgsConstructor
-@Getter
 public class AbstractResponse implements Serializable {
 
     private static final long serialVersionUID = -2762361600162949130L;
 
-    private List<MessagePair> messagePairList = new ArrayList<>();
+    private final List<MessagePair> messagePairList = new ArrayList<>();
 
     public void addMessagePair(@NonNull final MessagePair messagePair) {
         //Objects.requireNonNull(messagePair,"Error: messagePair is marked non-null but is null");

--- a/src/main/java/com/froyo/messages/MessagePair.java
+++ b/src/main/java/com/froyo/messages/MessagePair.java
@@ -1,7 +1,6 @@
 package com.froyo.messages;
 
 import lombok.AllArgsConstructor;
-import lombok.Data;
 import lombok.Getter;
 
 import javax.validation.constraints.NotBlank;
@@ -14,10 +13,10 @@ public class MessagePair implements Serializable {
 
     private static final long serialVersionUID = 2734364864701881278L;
 
-    private String code;
+    private final String code;
     @NotBlank
-    private String description;
+    private final String description;
     @NotNull
-    private MessagePairTypeCode messagePairTypeCode;
+    private final MessagePairTypeCode messagePairTypeCode;
 
 }

--- a/src/main/java/com/froyo/messages/codes/CurrencyMessageCode.java
+++ b/src/main/java/com/froyo/messages/codes/CurrencyMessageCode.java
@@ -3,7 +3,6 @@ package com.froyo.messages.codes;
 import com.froyo.messages.MessagePairTypeCode;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.ToString;
 
 import java.io.Serializable;
 
@@ -22,8 +21,8 @@ public enum CurrencyMessageCode implements Serializable {
     CY_1101("CY-1101", "Error when try to save currency", ERROR), //
     CY_1102("CY-1102", "Save currency successfully", SUCCESS);
 
-    private String code;
-    private String description;
-    private MessagePairTypeCode messagePairTypeCode;
+    private final String code;
+    private final String description;
+    private final MessagePairTypeCode messagePairTypeCode;
 
 }

--- a/src/main/java/com/froyo/messages/codes/FilesMessageCode.java
+++ b/src/main/java/com/froyo/messages/codes/FilesMessageCode.java
@@ -3,7 +3,6 @@ package com.froyo.messages.codes;
 import com.froyo.messages.MessagePairTypeCode;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.ToString;
 
 import java.io.Serializable;
 
@@ -22,8 +21,8 @@ public enum FilesMessageCode implements Serializable {
     FILE_1101("FILE-1101", "Error upload photo", ERROR), //
     FILE_1102("FILE-1102", "Success to save album", SUCCESS);
 
-    private String code;
-    private String description;
-    private MessagePairTypeCode messagePairTypeCode;
+    private final String code;
+    private final String description;
+    private final MessagePairTypeCode messagePairTypeCode;
 
 }

--- a/src/main/java/com/froyo/messages/exceptions/ValidationConstraintRemote.java
+++ b/src/main/java/com/froyo/messages/exceptions/ValidationConstraintRemote.java
@@ -5,23 +5,23 @@ import lombok.Getter;
 import lombok.NonNull;
 
 import javax.validation.ConstraintViolation;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
 public class ValidationConstraintRemote extends RuntimeException {
 
-    private String exceptionMessage;
-    private List<Set<ConstraintViolation<MessagePair>>> listOfConstraintsFound;
+    private final String exceptionMessage;
+    private final List<Set<ConstraintViolation<MessagePair>>> listOfConstraintsFound;
 
     private ValidationConstraintRemote(){
         throw new AssertionError();
     }
 
     public ValidationConstraintRemote(@NonNull List<Set<ConstraintViolation<MessagePair>>> listOfConstraintsFound){
+        super("Please check the constraints for <<MessagePair>> class");
         this.exceptionMessage = "Please check the constraints for <<MessagePair>> class";
-        this.listOfConstraintsFound = listOfConstraintsFound;
+        this.listOfConstraintsFound = Collections.unmodifiableList(listOfConstraintsFound);
     }
 
     public String getExceptionMessage() {
@@ -29,7 +29,7 @@ public class ValidationConstraintRemote extends RuntimeException {
     }
 
     public List<Set<ConstraintViolation<MessagePair>>> getListOfConstraintsFound() {
-        return Collections.unmodifiableList(this.listOfConstraintsFound);
+        return this.listOfConstraintsFound;
     }
 
 }


### PR DESCRIPTION
## Summary
- simplify AbstractResponse by removing Lombok getter and making the list final
- make MessagePair and code enums immutable
- clean up ValidationConstraintRemote and ensure immutability

## Testing
- `mvn test` *(fails: Could not transfer artifact org.jacoco:jacoco-maven-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_6850690df35c832ebf250e6a4a9d3120